### PR TITLE
Fix error when there are empty lines in real certificate file

### DIFF
--- a/certmitm/certtest.py
+++ b/certmitm/certtest.py
@@ -65,6 +65,9 @@ def generate_test_context(original_cert_chain_pem, hostname, working_dir, logger
             certcontent = certf.read()
         buffer = ""
         for i in certcontent.split("\n"):
+            # Skip empty lines in certificate files
+            if not i.strip():
+                continue
             if "CERTIFICATE" in i:
                 if buffer:
                     buffer = f"-----BEGIN CERTIFICATE-----\n{buffer}-----END CERTIFICATE-----\n"


### PR DESCRIPTION
When there are empty lines in the fullchail certificate file in real_certs, empty lines are incorrectly interpreted as certificates. This causes `OpenSSL.crypto.load_certificate` to throw an error.

[acme.sh](https://github.com/acmesh-official/acme.sh), a widely-used tool for certificate management, produces certificate chains in a format with empty lines separating individual certificates:

```
-----BEGIN CERTIFICATE-----
...
-----END CERTIFICATE-----

-----BEGIN CERTIFICATE-----
...
-----END CERTIFICATE-----

```

```
Traceback (most recent call last):
  File ".../certmitm/certmitm.py", line 55, in threaded_connection_handler
    test = connection_tests.get_test(connection)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../certmitm/certmitm/connection.py", line 72, in get_test
    next_test = self.all_test_dict[connection.identifier].get_test()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../certmitm/certmitm/connection.py", line 123, in get_test
    for test in certmitm.certtest.generate_test_context(self.upstream_cert_fullchain, self.connection.upstream_sni or self.connection.upstream_ip, self.working_dir, self.logger):
  File ".../certmitm/certmitm/certtest.py", line 87, in generate_test_context
    cert = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, real_cert_pem)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../certmitm/lib/python3.12/site-packages/OpenSSL/crypto.py", line 2090, in load_certificate
    _raise_current_error()
  File ".../.pyenv/versions/certmitm/lib/python3.12/site-packages/OpenSSL/_util.py", line 57, in exception_from_error_queue
    raise exception_type(errors)
```

This fix modifies the certificate processing to skip empty lines, ensuring that only valid certificates are passed to `OpenSSL.crypto.load_certificate`. This change enhances compatibility with acme.sh output and prevents unnecessary errors.