### PR TITLE
Update README with TLS session secrets logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ test@victim:~$ curl --insecure https://www.google.com
 <!doctype html><html itemscope="" itemtype="http://schema.org/WebPage" lang="fi"><head><meta content="text/html;
 ```
 
+To log TLS session secrets for successfully intercepted TLS connections, you can set the SSLKEYLOGFILE environment variable. This file can then be used to decrypt the captured TLS traffic in tools such as Wireshark (_Edit → Preferences → Protocols → TLS → (Pre)-Master-Secret log filename_). 
+
+```
+SSLKEYLOGFILE=sslkeylogfile.txt python3 certmitm.py --listen 9900 --workdir testing --verbose
+```
+
 ## Hall of fame
 
 List of publicly disclosed vulnerabilities found with certmitm. Open an issue if you have found a vulnerability with certmitm and want to be included.


### PR DESCRIPTION
I wanted to add support for SSLKEYLOGFILE so that I could create a pcap capture of the traffic, and decrypt this in Wireshark. But as it turns out, since Python 3.8, `ssl.create_default_context`, which this application uses, [already supports this](https://docs.python.org/3/library/ssl.html#ssl.create_default_context):

> When [keylog_filename](https://docs.python.org/3/library/ssl.html#ssl.SSLContext.keylog_filename) is supported and the environment variable SSLKEYLOGFILE is set, [create_default_context()](https://docs.python.org/3/library/ssl.html#ssl.create_default_context) enables key logging.

I added some documentation to the README explaining the usage of the key log file.

P.S. sorry for the double PR, apparently renaming a branch after creating a PR closes it automatically.