### PR TITLE
Restrict pyOpenSSL version to less than 23.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pyOpenSSL
+pyOpenSSL<23.3.0
 dpkt


### PR DESCRIPTION
Newer versions of `pyOpenSSL` deprecated `X509.Extensions`. 
Reference: https://github.com/pyca/pyopenssl/issues/1295